### PR TITLE
Improve bump-message

### DIFF
--- a/bump-bot/bump_bot.py
+++ b/bump-bot/bump_bot.py
@@ -34,11 +34,13 @@ async def reaction_changed(payload: discord.RawReactionActionEvent, added: bool)
 	
 	message = await message_cache.get_message(payload.message_id, channel)	
 	if message:
-		user = discord.utils.get(client.users, id=payload.user_id)
+
+		# There is not member field on reaction_removed events
+		member = discord.utils.get(client.get_all_members(), id=(payload.member.id if payload.member is not None else payload.user_id))
 		if added:
-			found_reactions_cache.add_found_reaction(payload.message_id, payload.emoji, user)
+			found_reactions_cache.add_found_reaction(payload.message_id, payload.emoji, member)
 		else:
-			found_reactions_cache.remove_found_reaction(payload.message_id, payload.emoji, user)
+			found_reactions_cache.remove_found_reaction(payload.message_id, payload.emoji, member)
 		await bump_message.update_bump_message(message)
 
 @client.event

--- a/bump-bot/bump_bot.py
+++ b/bump-bot/bump_bot.py
@@ -35,8 +35,8 @@ async def reaction_changed(payload: discord.RawReactionActionEvent, added: bool)
 	message = await message_cache.get_message(payload.message_id, channel)	
 	if message:
 
-		# reaction_removed events have no "member", so we grab them via the user_id
-		member = discord.utils.get(client.get_all_members(), id=(payload.member.id if payload.member is not None else payload.user_id))
+		# reaction_removed events do not have a member included while reaction_added ones do.
+		member = channel.guild.get_member(payload.user_id)
 		if added:
 			found_reactions_cache.add_found_reaction(payload.message_id, payload.emoji, member)
 		else:

--- a/bump-bot/bump_bot.py
+++ b/bump-bot/bump_bot.py
@@ -35,7 +35,7 @@ async def reaction_changed(payload: discord.RawReactionActionEvent, added: bool)
 	message = await message_cache.get_message(payload.message_id, channel)	
 	if message:
 
-		# There is not member field on reaction_removed events
+		# reaction_removed events have no "member", so we grab them via the user_id
 		member = discord.utils.get(client.get_all_members(), id=(payload.member.id if payload.member is not None else payload.user_id))
 		if added:
 			found_reactions_cache.add_found_reaction(payload.message_id, payload.emoji, member)

--- a/bump-bot/bump_bot.py
+++ b/bump-bot/bump_bot.py
@@ -35,7 +35,6 @@ async def reaction_changed(payload: discord.RawReactionActionEvent, added: bool)
 	message = await message_cache.get_message(payload.message_id, channel)	
 	if message:
 
-		# reaction_removed events do not have a member included while reaction_added ones do.
 		member = channel.guild.get_member(payload.user_id)
 		if added:
 			found_reactions_cache.add_found_reaction(payload.message_id, payload.emoji, member)

--- a/bump-bot/bump_message.py
+++ b/bump-bot/bump_message.py
@@ -12,24 +12,24 @@ def get_emoji(emoji_string: str):
 	return emoji_string
 
 def bump_message_embed(found_reactions: found_reactions_cache.FoundReactions):
-	users_who_voted = set()
+	members_who_voted = set()
 	for reaction in found_reactions:
-		users_who_voted = users_who_voted.union(found_reactions[reaction])
+		members_who_voted = members_who_voted.union(found_reactions[reaction])
 
 	message_text = "Current Voters: "
 
-	if len(users_who_voted) == 0:
+	if len(members_who_voted) == 0:
 		message_text += "No votes yet"
 	else:
-		user : discord.User
-		for user in users_who_voted:
-			message_text += user.display_name
+		member : discord.Member
+		for member in members_who_voted:
+			message_text += member.display_name
 			message_text += ", "
 		message_text = message_text.removesuffix(", ")
 	
 	message_text += " "
 
-	if len(users_who_voted) >= config.get_required_votes():
+	if len(members_who_voted) >= config.get_required_votes():
 		message_text += ":white_check_mark:"
 	else:
 		message_text += ":x:"
@@ -37,24 +37,27 @@ def bump_message_embed(found_reactions: found_reactions_cache.FoundReactions):
 	message_text += "\n"
 
 	for reaction in config.get_reactions():
-		users = []
+		members = []
 		if reaction in found_reactions:
-			users = found_reactions[reaction]
+			members = found_reactions[reaction]
 
-		if len(users) == len(users_who_voted):
+		if len(members) == len(members_who_voted):
 			message_text += ":white_check_mark:"
 		else:
 			message_text += ":x:"
 
 		message_text += " {} ({}): ".format(config.get_reactions()[reaction], get_emoji(reaction))
 
-		if len(users) == 0:
+
+		if len(members) == 0:
 			message_text += "No one"
-		else:
-			for user in users:
-				message_text += user.display_name
+		elif len(members) < len(members_who_voted):
+			for member in members:
+				message_text += member.display_name
 				message_text += ", "
 			message_text = message_text.removesuffix(", ")
+		elif len(members) == len(members_who_voted):
+			message_text += "Everyone!" 
 
 		message_text += '\n'
 	

--- a/bump-bot/found_reactions_cache.py
+++ b/bump-bot/found_reactions_cache.py
@@ -4,7 +4,7 @@ import discord
 import config
 import discord_client
 
-FoundReactions = Dict[str, List[discord.User]]
+FoundReactions = Dict[str, List[discord.Member]]
 
 found_reactions_cache: Dict[int, FoundReactions] = {}
 
@@ -34,10 +34,10 @@ def initialize_found_reactions(message: discord.Message):
 		found_reactions[emoji_string] = []
 	found_reactions_cache[message.id] = found_reactions
 
-def add_found_reaction(message_id: int, emoji: discord.PartialEmoji, user: discord.User|discord.Member):
+def add_found_reaction(message_id: int, emoji: discord.PartialEmoji, member: discord.Member):
 	if message_id in found_reactions_cache:
-		found_reactions_cache[message_id][emoji.name].append(user)
+		found_reactions_cache[message_id][emoji.name].append(member)
 
-def remove_found_reaction(message_id: int, emoji: discord.PartialEmoji, user: discord.User|discord.Member):
+def remove_found_reaction(message_id: int, emoji: discord.PartialEmoji, member: discord.Member):
 	if message_id in found_reactions_cache:
-		found_reactions_cache[message_id][emoji.name].remove(user)
+		found_reactions_cache[message_id][emoji.name].remove(member)


### PR DESCRIPTION
- Changes the reaction-cache to use members instead of users (almost the same, but members are coined to the discord servers/ guild and thus use the server nicknames)
- Displays "Everyone!" instead of enumerating all names when everyone voted for an option